### PR TITLE
remove trailing commas in config.json-example

### DIFF
--- a/config.json-example
+++ b/config.json-example
@@ -7,8 +7,8 @@
     "dev" : {
       "logfile" : "xlogfile",
       "display" : "Development server",
-      "dumplog" : "test_%U_%u_%s_%e",
-    },
+      "dumplog" : "test_%U_%u_%s_%e"
+    }
   },
 
   #---------------------------------------------------------------------------
@@ -21,7 +21,7 @@
 
   "time" : {
     "starttime" : 1541026800,
-    "endtime"   : 1543618800,
+    "endtime"   : 1543618800
   },
 
   #---------------------------------------------------------------------------
@@ -36,7 +36,7 @@
 
   "scum" : {
     # "minturns" : 10,
-    "minquitturns": 100,
+    "minquitturns": 100
   },
 
   #---------------------------------------------------------------------------
@@ -46,7 +46,7 @@
   "templates"  : {
     "include"  : "templates/include",
     "path"     : "templates",
-    "html"     : "www",
+    "html"     : "www"
   },
 
   #---------------------------------------------------------------------------
@@ -89,7 +89,7 @@
     "endtime",
     "gender0",
     "align0",
-    "src",
+    "src"
   ],
 
   #---------------------------------------------------------------------------
@@ -100,190 +100,190 @@
 
     "firstasc" : {
       "title"  : "First Ascension",
-      "points" : 150,
+      "points" : 150
     },
 
     "clan-firstasc" : {
       "title"  : "First Ascension",
-      "points" : 150,
+      "points" : 150
     },
 
     "mostasc"  : {
       "title"  : "Most Ascensions",
-      "points" : 250,
+      "points" : 250
     },
 
     "clan-mostasc"  : {
       "title"  : "Most Ascensions",
-      "points" : 250,
+      "points" : 250
     },
 
     "mostcond" : {
       "title"  : "Most Conducts in One Ascension",
-      "points" : 250,
+      "points" : 250
     },
 
     "clan-mostcond" : {
       "title"  : "Most Conducts in One Ascension",
-      "points" : 250,
+      "points" : 250
     },
 
     "lowscore" : {
       "title"  : "Lowest Scoring Ascension",
-      "points" : 150,
+      "points" : 150
     },
 
     "clan-lowscore" : {
       "title"  : "Lowest Scoring Ascension",
-      "points" : 150,
+      "points" : 150
     },
 
     "highscore" : {
       "title"  : "Highest Scoring Ascension",
-      "points" : 150,
+      "points" : 150
     },
 
     "clan-highscore" : {
       "title"  : "Highest Scoring Ascension",
-      "points" : 150,
+      "points" : 150
     },
 
     "maxstreak" : {
       "title"  : "Longest Streak",
-      "points" : 250,
+      "points" : 250
     },
 
     "clan-maxstreak" : {
       "title"  : "Longest Streak",
-      "points" : 250,
+      "points" : 250
     },
 
     "minturns" : {
       "title"  : "Lowest Turncount",
-      "points" : 250,
+      "points" : 250
     },
 
     "clan-minturns" : {
       "title"  : "Lowest Turncount",
-      "points" : 250,
+      "points" : 250
     },
 
     "realtime" : {
       "title"  : "Fastest Realtime",
-      "points" : 250,
+      "points" : 250
     },
 
     "clan-realtime" : {
       "title"  : "Fastest Realtime",
-      "points" : 250,
+      "points" : 250
     },
 
     "streak"   : {
-      "title"  : "Streak",
+      "title"  : "Streak"
     },
 
     "ascension" : {
       "title"  : "Ascension",
-      "points" : 50,
+      "points" : 50
     },
 
     "clan-ascension" : {
       "title"  : "Ascension",
-      "points" : 50,
+      "points" : 50
     },
 
     "conduct" : {
-      "title" : "Conduct",
+      "title" : "Conduct"
     },
 
     "conduct:food" : {
       "title"  : "Conduct: Foodless",
       "points" : 30,
-      "multi"  : 2,
+      "multi"  : 2
     },
 
     "conduct:vegn" : {
       "title"  : "Conduct: Vegan",
       "points" : 15,
-      "multi"  : 1.4,
+      "multi"  : 1.4
     },
 
     "conduct:vegt" : {
       "title"  : "Conduct: Vegetarian",
       "points" : 5,
-      "multi"  : 1.1,
+      "multi"  : 1.1
     },
 
     "conduct:athe" : {
       "title"  : "Conduct: Atheist",
       "points" : 10,
-      "multi"  : 1.2,
+      "multi"  : 1.2
     },
 
     "conduct:weap" : {
       "title"  : "Conduct: Weaponless",
       "points" : 10,
-      "multi"  : 1.2,
+      "multi"  : 1.2
     },
 
     "conduct:paci" : {
       "title"  : "Conduct: Pacifist",
       "points" : 50,
-      "multi"  : 2,
+      "multi"  : 2
     },
 
     "conduct:illi" : {
       "title"  : "Conduct: Illiterate",
       "points" : 20,
-      "multi"  : 1.4,
+      "multi"  : 1.4
     },
 
     "conduct:pile" : {
       "title"  : "Conduct: Polypileless",
       "points" : 1,
-      "multi"  : 1.02,
+      "multi"  : 1.02
     },
 
     "conduct:self" : {
       "title"  : "Conduct: Polyselfless",
       "points" : 1,
-      "multi"  : 1.02,
+      "multi"  : 1.02
     },
 
     "conduct:wish" : {
       "title"  : "Conduct: Wishless",
       "points" : 4,
-      "multi"  : 1.1,
+      "multi"  : 1.1
     },
 
     "conduct:arti" : {
       "title"  : "Conduct: Artiwishless",
       "points" : 1,
-      "multi"  : 1.02,
+      "multi"  : 1.02
     },
 
     "conduct:geno" : {
       "title"  : "Conduct: Genocideless",
       "points" : 5,
-      "multi"  : 1.02,
+      "multi"  : 1.02
     },
 
     "conduct:elbe" : {
       "title"  : "Conduct: Elberethless",
       "points" : 20,
-      "multi"  : 1.1,
+      "multi"  : 1.1
     },
 
     "conduct:zen"  : {
       "title"  : "Conduct: Zen",
       "points" : 50,
-      "multi"  : 2.2,
+      "multi"  : 2.2
     },
 
     "conduct:nude" : {
       "title"  : "Conduct: Nude",
       "points" : 50,
-      "multi"  : 2,
+      "multi"  : 2
     },
 
     # speedrunning bonus is int(factor / turns); if cutoff is defined then
@@ -292,290 +292,290 @@
     "speedrun" : {
       "title"  : "Speedrun",
       "factor" : 500000,
-      "cutoff" : null,
+      "cutoff" : null
     },
 
     "greatrace:orc" : {
       "title"  : "The Great Orc",
-      "points" : 200,
+      "points" : 200
     },
 
     "greatrace:gno" : {
       "title"  : "The Great Gnome",
-      "points" : 250,
+      "points" : 250
     },
 
     "greatrace:dwa" : {
       "title"  : "The Great Dwarf",
-      "points" : 150,
+      "points" : 150
     },
 
     "greatrace:elf" : {
       "title"  : "The Great Elf",
-      "points" : 150,
+      "points" : 150
     },
 
     "greatrace:hum" : {
       "title"  : "The Great Human",
-      "points" : 200,
+      "points" : 200
     },
 
     "greatrole:arc" : {
       "title"  : "The Great Archeologist",
-      "points" : 200,
+      "points" : 200
     },
 
     "greatrole:arc" : {
       "title"  : "The Great Archeologist",
-      "points" : 200,
+      "points" : 200
     },
 
     "greatrole:bar" : {
       "title"  : "The Great Barbarian",
-      "points" : 150,
+      "points" : 150
     },
 
     "greatrole:cav" : {
       "title"  : "The Great Caveman",
-      "points" : 200,
+      "points" : 200
     },
 
     "greatrole:hea" : {
       "title"  : "The Great Healer",
-      "points" : 100,
+      "points" : 100
     },
 
     "greatrole:mon" : {
       "title"  : "The Great Monk",
-      "points" : 150,
+      "points" : 150
     },
 
     "greatrole:pri" : {
       "title"  : "The Great Priest",
-      "points" : 200,
+      "points" : 200
     },
 
     "greatrole:ran" : {
       "title"  : "The Great Ranger",
-      "points" : 250,
+      "points" : 250
     },
 
     "greatrole:rog" : {
       "title"  : "The Great Rogue",
-      "points" : 100,
+      "points" : 100
     },
 
     "greatrole:val" : {
       "title"  : "The Great Valkyrie",
-      "points" : 150,
+      "points" : 150
     },
 
     "greatrole:wiz" : {
       "title"  : "The Great Wizard",
-      "points" : 150,
+      "points" : 150
     },
 
     "lesserrace:orc" : {
       "title"  : "The Lesser Orc",
-      "points" : 200,
+      "points" : 200
     },
 
     "lesserrace:gno" : {
       "title"  : "The Lesser Gnome",
-      "points" : 250,
+      "points" : 250
     },
 
     "lesserrace:dwa" : {
       "title"  : "The Lesser Dwarf",
-      "points" : 150,
+      "points" : 150
     },
 
     "lesserrace:elf" : {
       "title"  : "The Lesser Elf",
-      "points" : 150,
+      "points" : 150
     },
 
     "lesserrace:hum" : {
       "title"  : "The Lesser Human",
-      "points" : 200,
+      "points" : 200
     },
 
     "lesserrole:arc" : {
       "title"  : "The Lesser Archeologist",
-      "points" : 200,
+      "points" : 200
     },
 
     "lesserrole:arc" : {
       "title"  : "The Lesser Archeologist",
-      "points" : 200,
+      "points" : 200
     },
 
     "lesserrole:bar" : {
       "title"  : "The Lesser Barbarian",
-      "points" : 150,
+      "points" : 150
     },
 
     "lesserrole:cav" : {
       "title"  : "The Lesser Caveman",
-      "points" : 200,
+      "points" : 200
     },
 
     "lesserrole:hea" : {
       "title"  : "The Lesser Healer",
-      "points" : 100,
+      "points" : 100
     },
 
     "lesserrole:mon" : {
       "title"  : "The Lesser Monk",
-      "points" : 150,
+      "points" : 150
     },
 
     "lesserrole:pri" : {
       "title"  : "The Lesser Priest",
-      "points" : 200,
+      "points" : 200
     },
 
     "lesserrole:ran" : {
       "title"  : "The Lesser Ranger",
-      "points" : 250,
+      "points" : 250
     },
 
     "lesserrole:rog" : {
       "title"  : "The Lesser Rogue",
-      "points" : 100,
+      "points" : 100
     },
 
     "lesserrole:val" : {
       "title"  : "The Lesser Valkyrie",
-      "points" : 150,
+      "points" : 150
     },
 
     "lesserrole:wiz" : {
       "title"  : "The Lesser Wizard",
-      "points" : 150,
+      "points" : 150
     },
 
     "allroles" : {
       "title"  : "All The Roles",
-      "points" : 260,
+      "points" : 260
     },
 
     "clan-allroles" : {
       "title"  : "All The Roles",
-      "points" : 260,
+      "points" : 260
     },
 
     "allraces" : {
       "title"  : "All The Races",
-      "points" : 100,
+      "points" : 100
     },
 
     "clan-allraces" : {
       "title"  : "All The Races",
-      "points" : 100,
+      "points" : 100
     },
 
     "allgenders" : {
       "title"  : "Both Genders",
-      "points" : 40,
+      "points" : 40
     },
 
     "clan-allgenders" : {
       "title"  : "Both Genders",
-      "points" : 40,
+      "points" : 40
     },
 
     "allaligns" : {
       "title"  : "All The Alignments",
-      "points" : 60,
+      "points" : 60
     },
 
     "clan-allaligns" : {
       "title"  : "All The Alignments",
-      "points" : 60,
+      "points" : 60
     },
 
     "allconducts" : {
       "title"  : "All The Conducts",
-      "points" : 300,
+      "points" : 300
     },
 
     "clan-allconducts" : {
       "title"  : "All The Conducts",
-      "points" : 300,
+      "points" : 300
     },
 
     "ach" : {
       "title"  : "Achievement",
-      "points" : 1,
+      "points" : 1
     },
 
     "clan-ach" : {
       "title"  : "Achievement",
-      "points" : 1,
+      "points" : 1
     },
 
     "clan-uniqascs" : {
       "title"  : "Most Unique Ascensions",
-      "points" : 200,
+      "points" : 200
     },
 
     "clan-mostgames" : {
       "title"  : "Most Games",
-      "points" : 100,
+      "points" : 100
     },
 
     "clan-allcombos" : {
       "title"  : "NetHack Master",
-      "points" : 1000,
+      "points" : 1000
     },
 
     "clan-allcomcon" : {
       "title"  : "NetHack Dominator",
-      "points" : 2000,
+      "points" : 2000
     },
 
     "gimpossible" : {
       "title"  : "The Great Impossible",
-      "points" : 5000,
+      "points" : 5000
     },
 
     "clan-gimpossible" : {
       "title"  : "The Great Impossible",
-      "points" : 5000,
+      "points" : 5000
     },
 
     "rsimpossible" : {
       "title"  : "The Respectably-Sized Impossible",
-      "points" : 500,
+      "points" : 500
     },
 
     "clan-rsimpossible" : {
       "title"  : "The Respectably-Sized Impossible",
-      "points" : 500,
+      "points" : 500
     },
 
     "clan-medusacup" : {
       "title"  : "The Medusa Cup",
-      "points" : 100,
+      "points" : 100
     },
 
     "clan-uniquedeaths" : {
       "title"  : "Unique Deaths",
-      "points" : 200,
+      "points" : 200
     },
 
     "allachieve" : {
-      "title" : "All Achievements",
+      "title" : "All Achievements"
     },
 
     "clan-allachieve" : {
-      "title" : "All Achievements",
+      "title" : "All Achievements"
     },
 
     "noscum" : {
       "title"  : "Never Scum a Game",
-      "points" : 10,
+      "points" : 10
     },
 
     #--- great race/role -----------------------------------------------------
@@ -884,7 +884,7 @@
     "clan-lesserrole:wiz" : {
       "title"  : "Lesser Wizard",
       "points" : 25
-    },
+    }
 
   },
 
@@ -907,24 +907,24 @@
       "512"  : "wish",
       "1024" : "arti",
       "2048" : "geno",
-      "4096" : "elbe",
+      "4096" : "elbe"
     },
 
     "achieve" : {
       "4096" : "zen",
-      "8192" : "nude",
+      "8192" : "nude"
     },
 
     "order" : [
       "arti", "pile", "self", "geno", "wish", "athe", "vegt", "vegn", "weap",
-      "elbe", "illi", "paci", "food", "zen", "nude",
+      "elbe", "illi", "paci", "food", "zen", "nude"
     ],
 
     # this defines what counts as "all conducts"
 
     "all" : [
       "arti", "pile", "self", "geno", "wish", "athe", "vegt", "vegn", "weap",
-      "illi", "paci", "food",
+      "illi", "paci", "food"
     ],
 
     # this defines, for scoring purposes, conducts, that imply another one or
@@ -934,8 +934,8 @@
       [ "illi", "elbe" ],
       [ "food", "vegt", "vegn" ],
       [ "vegn", "vegt" ],
-      [ "wish", "arti" ],
-    ],
+      [ "wish", "arti" ]
+    ]
   },
 
   #---------------------------------------------------------------------------
@@ -1954,7 +1954,7 @@
       "tnntachieve2" : "0x10000000",
       "title"        : "Dust to Dust",
       "descr"        : "Wrest one last charge from a wand of wishing"
-    },
+    }
 
   },
 
@@ -1974,7 +1974,7 @@
     ],
 
     "aligns" : [
-      "Law", "Neu", "Cha",
+      "Law", "Neu", "Cha"
     ],
 
     "genders" : [
@@ -2066,7 +2066,7 @@
       "Wiz-Gno-Mal-Neu",
       "Wiz-Gno-Fem-Neu",
       "Wiz-Orc-Mal-Cha",
-      "Wiz-Orc-Fem-Cha",
+      "Wiz-Orc-Fem-Cha"
     ],
 
     # note that in Great Monk there's special case as you only need one monk,
@@ -2097,7 +2097,7 @@
       "Wiz" : [
         "Wiz-Hum-Neu", "Wiz-Hum-Cha", "Wiz-Elf-Cha", "Wiz-Gno-Neu", "Wiz-Orc-Cha"
       ]
-    },
+    }
 
   },
 
@@ -2110,7 +2110,7 @@
     "reject" : [
       "^ascended",
       "^quit",
-      "^escaped",
+      "^escaped"
     ],
 
     "normalize" : [
@@ -2134,7 +2134,7 @@
       [ "wrath of .+", "wrath of a deity" ],
       [ "priest(ess)?", "priest(ess)" ],
       [ "priest\\(ess\\) of .+", "priest(ess) of a deity" ],
-      [ "(\\w+ elemental|Aleax|couatl|Angel|\\w+ demon|\\w+ devil|(suc|in)cubus|balrog|pit fiend|nalfeshnee|hezrou|vrock|marilith|erinyes) of .+", "minion of a deity" ],
+      [ "(\\w+ elemental|Aleax|couatl|Angel|\\w+ demon|\\w+ devil|(suc|in)cubus|balrog|pit fiend|nalfeshnee|hezrou|vrock|marilith|erinyes) of .+", "minion of a deity" ]
     ]
   }
 }


### PR DESCRIPTION
Some json parsers choke on lists with a trailing ',' before '}'